### PR TITLE
Remove lexical-binding setting, change package description

### DIFF
--- a/peep-dired.el
+++ b/peep-dired.el
@@ -1,4 +1,4 @@
-;;; peep-dired.el --- A minor mode for dired buffers which allows to peep files in other window  -*- lexical-binding: t; -*-
+;;; peep-dired.el --- Peep at files in another window from dired buffers
 
 ;; Copyright (C) 2014  Adam Sokolnicki
 


### PR DESCRIPTION
`lexical-binding` is included by default in `auto-insert-mode`'s template, but it implies that the code will only work correctly in Emacs 24, which isn't the case here. :-)
