### PR TITLE
Add User Customizable List of Extensions to Ignore

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,14 @@ Adjust the state name depending on an evil state you open dired in:
 
 For now the buffers opened when browsing a directory will not be killed until disabling the mode. If you want kill them manually you can run command `peep-dired-kill-buffers-without-window`.
 
+## Ignoring Certain File Extensions
+
+You probably don't want to open certain files like videos when using Peep Dired. To ignore certain files when moving over them you can customize the following to your liking:
+
+```
+(setq peep-dired-ignored-extensions '("mkv" "iso" "mp4"))
+```
+
 ## Contribution
 
 Install [cask](https://github.com/rejeep/cask.el) if you haven't already, then:

--- a/peep-dired.el
+++ b/peep-dired.el
@@ -51,6 +51,12 @@
   :group 'peep-dired
   :type 'boolean)
 
+(defcustom peep-dired-ignored-extensions
+  '("mkv" "iso" "mp4")
+  "Extensions to not try to open"
+  :group 'peep-dired
+  :type 'list)
+
 (defun peep-dired-next-file ()
   (interactive)
   (dired-next-line 1)
@@ -70,15 +76,16 @@
 
 (defun peep-dired-display-file-other-window ()
   (let ((entry-name (dired-file-name-at-point)))
-    (add-to-list 'peep-dired-peeped-buffers
-		 (window-buffer
-		  (display-buffer
-		   (or
-		       (find-buffer-visiting entry-name)
-		       (car (or (dired-buffers-for-dir entry-name) ()))
-		       (find-file-noselect entry-name))
-		   t))))
-  )
+    (unless (member (file-name-extension entry-name)
+                    peep-dired-ignored-extensions)
+      (add-to-list 'peep-dired-peeped-buffers
+                   (window-buffer
+                    (display-buffer
+                     (or
+                      (find-buffer-visiting entry-name)
+                      (car (or (dired-buffers-for-dir entry-name) ()))
+                      (find-file-noselect entry-name))
+                     t))))))
 
 (defun peep-dired-scroll-page-down ()
   (interactive)


### PR DESCRIPTION
This addresses issue #7. I added a couple default values because I can't think of any situation in which someone would want to open a video or iso in a buffer. It might be better to either add more extensions or empty the list entirely and leave it up to the user. For now, the peep buffer will just stay the same when moving over one of these files. It may be better display something else instead. 

If you think this is a good idea and are willing to merge it, I can update the readme to mention it as well.